### PR TITLE
Increased timeouts in checkAcceptInvitation function and in SovrinPub…

### DIFF
--- a/sovrin_client/anon_creds/sovrin_public_repo.py
+++ b/sovrin_client/anon_creds/sovrin_public_repo.py
@@ -184,7 +184,7 @@ class SovrinPublicRepo(PublicRepo):
         try:
             resp = await eventually(_ensureReqCompleted,
                                     req.key, self.client, clbk,
-                                    timeout=20, retryWait=0.5)
+                                    timeout=40, retryWait=1)
         except NoConsensusYet:
             raise TimeoutError('Request timed out')
         return resp

--- a/sovrin_client/test/agent/conftest.py
+++ b/sovrin_client/test/agent/conftest.py
@@ -408,7 +408,7 @@ def checkAcceptInvitation(emptyLooper,
         assert link.remoteIdentifier == inviteeAcceptanceId
         assert link.remoteEndPoint[1] == inviteeAgent.endpoint.ha[1]
 
-    emptyLooper.run(eventually(chk))
+    emptyLooper.run(eventually(chk, timeout=10, retryWait=0.2))
 
 
 def createAgentAndAddEndpoint(looper, agentNym, agentVerkey, agentPort, steward,


### PR DESCRIPTION
…licRepo._sendReq method to make the tests testAliceAcceptFaberInvitation and testAliceAcceptAcmeInvitation stably passed on Windows 10. (#15)