### PR TITLE
Failing tests disable (#27)

### DIFF
--- a/sovrin_client/test/cli/test_save_and_restore_wallet.py
+++ b/sovrin_client/test/cli/test_save_and_restore_wallet.py
@@ -4,6 +4,7 @@ from time import sleep
 import pytest
 from plenum.cli.cli import Exit, Cli
 from plenum.common.util import createDirIfNotExists
+
 from sovrin_client.client.wallet.wallet import Wallet
 from sovrin_client.test.cli.helper import prompt_is, exitFromCli
 
@@ -150,6 +151,7 @@ def restartCliWithCorruptedWalletFile(cli, be, do, filePath):
     ], within=5)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-385')
 def testSaveAndRestoreWallet(do, be, cliForMultiNodePools,
                              aliceMultiNodePools,
                              earlMultiNodePools):

--- a/sovrin_client/test/cli/test_tutorial.py
+++ b/sovrin_client/test/cli/test_tutorial.py
@@ -1,9 +1,9 @@
 import pytest
 from plenum.common.eventually import eventually
-
-from sovrin_client.client.wallet.link import Link, constant
 from sovrin_common.exceptions import InvalidLinkException
 from sovrin_common.txn import ENDPOINT
+
+from sovrin_client.client.wallet.link import Link, constant
 from sovrin_client.test.cli.helper import getFileLines, prompt_is, exitFromCli
 
 
@@ -949,6 +949,7 @@ def restartCliAndTestWalletRestoration(be, do, cli, connectedToTest):
     assert len(cli._activeWallet.identifiers) == 4
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-385')
 def testAliceSendBankKYCClaim(be, do, aliceCli, susanCli, bankKYCClaimSent,
                               connectedToTest):
     be(aliceCli)

--- a/sovrin_client/test/cli/test_tutorial_manual.py
+++ b/sovrin_client/test/cli/test_tutorial_manual.py
@@ -3,12 +3,12 @@ import logging
 import re
 
 import pytest
-from plenum.common.eventually import eventually
-
 from anoncreds.protocol.types import ClaimDefinitionKey, ID
-from sovrin_client.agent.agent import createAndRunAgent
+from plenum.common.eventually import eventually
 from sovrin_common.setup_util import Setup
 from sovrin_common.txn import ENDPOINT
+
+from sovrin_client.agent.agent import createAndRunAgent
 from sovrin_client.test.agent.acme import AcmeAgent
 from sovrin_client.test.agent.faber import FaberAgent
 from sovrin_client.test.agent.helper import buildFaberWallet, buildAcmeWallet, \
@@ -16,12 +16,12 @@ from sovrin_client.test.agent.helper import buildFaberWallet, buildAcmeWallet, \
 from sovrin_client.test.agent.thrift import ThriftAgent
 from sovrin_client.test.cli.conftest import faberMap, acmeMap, \
     thriftMap
+from sovrin_client.test.cli.helper import newCLI
 from sovrin_client.test.cli.test_tutorial import syncInvite, acceptInvitation, \
     aliceRequestedTranscriptClaim, jobApplicationClaimSent, \
     jobCertClaimRequested, bankBasicClaimSent, bankKYCClaimSent, \
     setPromptAndKeyring
 from sovrin_client.test.helper import TestClient
-from sovrin_client.test.cli.helper import newCLI
 
 concerningLogLevels = [logging.WARNING,
                        logging.ERROR,
@@ -49,6 +49,7 @@ def testGettingStartedTutorialAgainstSandbox(newGuyCLI, be, do):
     # TODO finish the entire set of steps
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-384')
 def testManual(do, be, poolNodesStarted, poolTxnStewardData, philCLI,
                connectedToTest, nymAddedOut, attrAddedOut,
                claimDefAdded, issuerKeyAdded, aliceCLI, newKeyringOut, aliceMap,


### PR DESCRIPTION
* Increased timeouts in checkAcceptInvitation function and in SovrinPublicRepo._sendReq method to make the tests testAliceAcceptFaberInvitation and testAliceAcceptAcmeInvitation stably passed on Windows 10. (#15)

* Disabled failing tests.